### PR TITLE
Removes installation of duplicate Maven plugin

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ OUTPUT_FILE_PREFIX_LINUX="eclipse-emoflon-linux"
 OUTPUT_FILE_PREFIX_WINDOWS="eclipse-emoflon-windows"
 OUTOUT_FILE_PREFIX_MACOS="eclipse-emoflon-macos"
 MIRROR="https://ftp.fau.de"
-UPDATESITES="https://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/,https://hallvard.github.io/plantuml/,https://www.kermeta.org/k2/update,https://www.genuitec.com/updates/devstyle/ci/,https://download.eclipse.org/releases/$VERSION,https://www.codetogether.com/updates/ci/,http://update.eclemma.org/,https://pmd.github.io/pmd-eclipse-plugin-p2-site/,https://checkstyle.org/eclipse-cs-update-site/,https://spotbugs.github.io/eclipse/,https://download.eclipse.org/technology/m2e/releases/latest,https://emoflon.org/emoflon-neo-updatesite/snapshot/"
+UPDATESITES="https://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/,https://hallvard.github.io/plantuml/,https://www.kermeta.org/k2/update,https://www.genuitec.com/updates/devstyle/ci/,https://download.eclipse.org/releases/$VERSION,https://www.codetogether.com/updates/ci/,http://update.eclemma.org/,https://pmd.github.io/pmd-eclipse-plugin-p2-site/,https://checkstyle.org/eclipse-cs-update-site/,https://spotbugs.github.io/eclipse/,https://emoflon.org/emoflon-neo-updatesite/snapshot/"
 EMOFLON_HEADLESS_SRC="https://api.github.com/repos/eMoflon/emoflon-headless/releases/latest"
 
 # Import plug-in:

--- a/packages/additional-packages.list
+++ b/packages/additional-packages.list
@@ -2,4 +2,3 @@ org.eclipse.eclemma.feature.feature.group
 net.sourceforge.pmd.eclipse.feature.group
 net.sf.eclipsecs.feature.group
 com.github.spotbugs.plugin.eclipse.feature.group
-org.eclipse.m2e.feature.feature.group


### PR DESCRIPTION
Fixes the latest broken CI: https://github.com/eMoflon/emoflon-neo-eclipse-build/actions/runs/8043839456